### PR TITLE
Fix: Stopwatch records point to wrong peaks

### DIFF
--- a/PeaksOfArchipelago/Patches/LocationDetectionPatches.cs
+++ b/PeaksOfArchipelago/Patches/LocationDetectionPatches.cs
@@ -265,16 +265,17 @@ namespace PeaksOfArchipelago.Patches
                 return;
             }
             Peaks peak = ItemTypes.PeakfromStamper(__instance.summitStamper.peakNames);
+            int peakNumber = __instance.peakNumber;
 
-            if (__instance.timer < timeAttackDefaultData.times[(int)peak])
+            if (__instance.timer < timeAttackDefaultData.times[peakNumber])
             {
                 Connection.Instance.CompleteTimePBLocation(peak);
             }
-            if (__instance.ropesUsed <= timeAttackDefaultData.ropes[(int)peak])
+            if (__instance.ropesUsed <= timeAttackDefaultData.ropes[peakNumber])
             {
                 Connection.Instance.CompleteRopePBLocation(peak);
             }
-            if (__instance.holdsMade < timeAttackDefaultData.holds[(int)peak])
+            if (__instance.holdsMade < timeAttackDefaultData.holds[peakNumber])
             {
                 Connection.Instance.CompleteHoldPBLocation(peak);
             }

--- a/PeaksOfArchipelago/Patches/LocationDetectionPatches.cs
+++ b/PeaksOfArchipelago/Patches/LocationDetectionPatches.cs
@@ -267,6 +267,12 @@ namespace PeaksOfArchipelago.Patches
             Peaks peak = ItemTypes.PeakfromStamper(__instance.summitStamper.peakNames);
             int peakNumber = __instance.peakNumber;
 
+            if (__instance.summitStamper.isCategory2) peakNumber += 20;
+            else if (__instance.summitStamper.isCategory3) peakNumber += 30;
+            else if (__instance.summitStamper.isAlps1) peakNumber += 35;
+            else if (__instance.summitStamper.isAlps2) peakNumber += 47;
+            else if (__instance.summitStamper.isAlps3) peakNumber += 52; 
+
             if (__instance.timer < timeAttackDefaultData.times[peakNumber])
             {
                 Connection.Instance.CompleteTimePBLocation(peak);


### PR DESCRIPTION
The peaks Hangman's Leap and Land's End, and Great Gaol and Eldenhorn were flipped for stopwatch records. This fix uses the peakNumber instead of the peaks enum to obtain the correct targets. 

This was tested by purposefully beating Land's End between 64 and 115 holds and confirming that the check was indeed sent. 