### PR TITLE
Fix: Ropes wouldn't spawn if player had 42+

### DIFF
--- a/PeaksOfArchipelago/Patches/LocationDetectionPatches.cs
+++ b/PeaksOfArchipelago/Patches/LocationDetectionPatches.cs
@@ -151,6 +151,7 @@ namespace PeaksOfArchipelago.Patches
         public static void StartPrefix(out int __state)
         {
             __state = GameManager.control.ropesCollected;
+            GameManager.control.ropesCollected = 0; // If you have 42 or more ropes, the game won't spawn any more. We'll set our ropes back to what it should be again in the postfix
         }
         
         [HarmonyPostfix]


### PR DESCRIPTION
If the player has 42 or more ropes, the game would not spawn rope collectibles any more, leading to impossible checks. This solution sets the ropesCollected to 0 before it performs its checks on whether to delete it or not, and then back to what it should be afterwards.

I tested this first by loading into Land's End and checking the rope was there. Giving myself way too many Extra Ropes, and confirming the rope was no longer spawned with the current mod. I then applied this fix, and confirmed that the rope continued to spawn even after giving myself all those Extra Ropes. I also tested to confirm the player had the correct number of usable ropes when they had 0, some number below 42, and over 42 ropes.

I noticed in the commit history you had a similar solution, but then removed it in the commit "[fix bug where allArtefacts would not be saved, fix bug with ropes being set to 0, fix climber given ropes not being detected sucessfully, increase progressView scroll speed](https://github.com/EliottDup/PeaksOfArchipelago/commit/70dc5bbee2cdbfd3471f500cbad99e9e4c431437)". I wasn't sure what that bug was referring to, so I can't test if it's still an issue here too. Apologies if it does still cause issues. 